### PR TITLE
Add .less to variables to allow importing

### DIFF
--- a/main.less
+++ b/main.less
@@ -1,5 +1,5 @@
 @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700|Inconsolata:400,700');
-@import './variables';
+@import './variables.less';
 
 // html/body
 html, *, *:before, *:after {


### PR DESCRIPTION
Less by itself doesn't seem to resolve `@import './variables';` in main.less when being used in the following manner where @planet/css is in node_modules:

`./node_modules/less/bin/lessc ./src/docs.less ./build/docs.css`

In docs.less, `@import (less) '../node_modules/@planet/css/lib/main';`

Without adding `.less`, the following error is reached:

```
FileError: './variables' wasn't found. Tried - /usr/local/apps/readmeio-docs/node_modules/@planet/css/lib/variables,/usr/local/apps/readmeio-docs/src/variables.less,/usr/local/apps/readmeio-docs/node_modules/variables,variables.less in /usr/local/apps/readmeio-docs/node_modules/@planet/css/lib/main.less on line 408, column 1:
407 @import url('https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,400,600,700|Inconsolata:400,700');
408 @import './variables';
```